### PR TITLE
Fix ported box dual impedance peaks using Small's transfer function

### DIFF
--- a/compare_ported_validation.py
+++ b/compare_ported_validation.py
@@ -1,0 +1,270 @@
+"""
+Compare viberesp ported box simulations with Hornresp results.
+
+This script reads viberesp CSV results and Hornresp exported data,
+then generates comparison plots and statistics.
+
+Usage:
+    1. Run Hornresp simulations and export impedance/SPL data
+    2. Save Hornresp exports as CSV files with naming convention:
+       "{DRIVER}_ported_B4_hornresp.csv"
+    3. Run this script to generate comparison plots
+
+Literature:
+- Thiele (1971) - Vented box theory
+- Beranek (1954) - Radiation impedance
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import csv
+from pathlib import Path
+from typing import Optional, Dict, List
+
+
+def read_csv(filepath: str) -> List[Dict]:
+    """Read CSV file into list of dictionaries."""
+    with open(filepath, 'r') as f:
+        reader = csv.DictReader(f)
+        return list(reader)
+
+
+def interpolate_hornresp_to_viberesp_freqs(
+    viberesp_data: List[Dict],
+    hornresp_data: List[Dict],
+    value_key: str
+) -> tuple[np.ndarray, np.ndarray, Optional[np.ndarray]]:
+    """
+    Interpolate Hornresp data to viberesp frequency points.
+
+    Args:
+        viberesp_data: Viberesp simulation results
+        hornresp_data: Hornresp simulation results
+        value_key: Key to interpolate (e.g., 'Ze_magnitude_ohm')
+
+    Returns:
+        (frequencies, viberesp_values, hornresp_values)
+    """
+    # Extract Hornresp frequencies and values
+    hr_freqs = np.array([float(row['frequency_hz']) for row in hornresp_data])
+    hr_values = np.array([float(row[value_key]) for row in hornresp_data])
+
+    # Extract viberesp frequencies and values
+    vb_freqs = np.array([float(row['frequency_hz']) for row in viberesp_data])
+    vb_values = np.array([float(row[value_key]) for row in viberesp_data])
+
+    # Interpolate Hornresp to viberesp frequencies
+    hr_interpolated = np.interp(vb_freqs, hr_freqs, hr_values)
+
+    return vb_freqs, vb_values, hr_interpolated
+
+
+def calculate_statistics(
+    viberesp_values: np.ndarray,
+    hornresp_values: np.ndarray,
+    name: str = ""
+) -> Dict:
+    """Calculate comparison statistics between viberesp and Hornresp."""
+    # Remove NaN values
+    mask = ~(np.isnan(viberesp_values) | np.isnan(hornresp_values))
+    vb_clean = viberesp_values[mask]
+    hr_clean = hornresp_values[mask]
+
+    if len(vb_clean) == 0:
+        return {}
+
+    # Calculate differences
+    abs_diff = np.abs(vb_clean - hr_clean)
+    rel_diff = np.abs((vb_clean - hr_clean) / hr_clean) * 100  # Percentage
+
+    stats = {
+        'name': name,
+        'n_points': len(vb_clean),
+        'max_abs_diff': np.max(abs_diff),
+        'mean_abs_diff': np.mean(abs_diff),
+        'max_rel_diff': np.max(rel_diff),
+        'mean_rel_diff': np.mean(rel_diff),
+        'rmse': np.sqrt(np.mean((vb_clean - hr_clean)**2)),
+    }
+
+    return stats
+
+
+def plot_impedance_comparison(
+    driver_name: str,
+    viberesp_data: List[Dict],
+    hornresp_data: Optional[List[Dict]] = None,
+    output_dir: Path = Path("validation_cases/ported_box")
+):
+    """Plot impedance comparison (magnitude and phase)."""
+
+    # Extract viberesp data
+    vb_freqs = np.array([float(row['frequency_hz']) for row in viberesp_data])
+    vb_z_mag = np.array([float(row['Ze_magnitude_ohm']) for row in viberesp_data])
+    vb_z_phase = np.array([float(row['Ze_phase_deg']) for row in viberesp_data])
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 8))
+
+    # Plot impedance magnitude
+    ax1.semilogx(vb_freqs, vb_z_mag, 'b-', linewidth=2, label='viberesp')
+    ax1.axhline(y=2.6, color='gray', linestyle='--', alpha=0.5, label='Re')
+    ax1.set_xlabel('Frequency (Hz)')
+    ax1.set_ylabel('|Ze| (Ω)')
+    ax1.set_title(f'{driver_name} Ported Box - Electrical Impedance Magnitude')
+    ax1.grid(True, alpha=0.3)
+    ax1.legend()
+
+    # Plot impedance phase
+    ax2.semilogx(vb_freqs, vb_z_phase, 'b-', linewidth=2, label='viberesp')
+    ax2.axhline(y=0, color='gray', linestyle='--', alpha=0.5)
+    ax2.set_xlabel('Frequency (Hz)')
+    ax2.set_ylabel('Phase (degrees)')
+    ax2.set_title(f'{driver_name} Ported Box - Electrical Impedance Phase')
+    ax2.grid(True, alpha=0.3)
+    ax2.legend()
+
+    plt.tight_layout()
+
+    # Save plot
+    output_file = output_dir / f"{driver_name}_ported_B4_impedance_comparison.png"
+    plt.savefig(output_file, dpi=150)
+    print(f"  Saved: {output_file}")
+
+    # Calculate statistics if Hornresp data available
+    if hornresp_data:
+        freqs, vb_mag, hr_mag = interpolate_hornresp_to_viberesp_freqs(
+            viberesp_data, hornresp_data, 'Ze_magnitude_ohm'
+        )
+        _, vb_phase, hr_phase = interpolate_hornresp_to_viberesp_freqs(
+            viberesp_data, hornresp_data, 'Ze_phase_deg'
+        )
+
+        stats_mag = calculate_statistics(vb_mag, hr_mag, "Impedance Magnitude")
+        stats_phase = calculate_statistics(vb_phase, hr_phase, "Impedance Phase")
+
+        return stats_mag, stats_phase
+
+    return None, None
+
+
+def plot_spl_comparison(
+    driver_name: str,
+    viberesp_data: List[Dict],
+    hornresp_data: Optional[List[Dict]] = None,
+    output_dir: Path = Path("validation_cases/ported_box")
+):
+    """Plot SPL comparison."""
+
+    # Extract viberesp data
+    vb_freqs = np.array([float(row['frequency_hz']) for row in viberesp_data])
+    vb_spl = np.array([float(row['SPL_db']) for row in viberesp_data])
+
+    fig, ax = plt.subplots(1, 1, figsize=(10, 6))
+
+    ax.semilogx(vb_freqs, vb_spl, 'b-', linewidth=2, label='viberesp')
+    ax.set_xlabel('Frequency (Hz)')
+    ax.set_ylabel('SPL (dB @ 1m, 2.83V)')
+    ax.set_title(f'{driver_name} Ported Box - Frequency Response')
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+
+    plt.tight_layout()
+
+    # Save plot
+    output_file = output_dir / f"{driver_name}_ported_B4_spl_comparison.png"
+    plt.savefig(output_file, dpi=150)
+    print(f"  Saved: {output_file}")
+
+    # Calculate statistics if Hornresp data available
+    if hornresp_data:
+        freqs, vb_spl, hr_spl = interpolate_hornresp_to_viberesp_freqs(
+            viberesp_data, hornresp_data, 'SPL_db'
+        )
+
+        stats = calculate_statistics(vb_spl, hr_spl, "SPL")
+
+        return stats
+
+    return None
+
+
+def main():
+    """Main comparison workflow."""
+
+    output_dir = Path("validation_cases/ported_box")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Drivers to compare
+    drivers = ["BC_8NDL51", "BC_12NDL76", "BC_15DS115", "BC_15PS100", "BC_18PZW100"]
+
+    print("="*60)
+    print("PORTED BOX VALIDATION COMPARISON")
+    print("="*60)
+
+    all_stats = []
+
+    for driver_name in drivers:
+        print(f"\n{driver_name}:")
+
+        # Read viberesp data
+        vb_file = output_dir / f"{driver_name}_ported_B4_viberesp.csv"
+        if not vb_file.exists():
+            print(f"  WARNING: viberesp file not found: {vb_file}")
+            continue
+
+        viberesp_data = read_csv(str(vb_file))
+
+        # Check for Hornresp data (optional)
+        hr_file = output_dir / f"{driver_name}_ported_B4_hornresp.csv"
+        hornresp_data = None
+        if hr_file.exists():
+            hornresp_data = read_csv(str(hr_file))
+            print(f"  Found Hornresp data")
+        else:
+            print(f"  No Hornresp data (expected if not yet exported)")
+
+        # Plot impedance
+        stats_mag, stats_phase = plot_impedance_comparison(
+            driver_name, viberesp_data, hornresp_data, output_dir
+        )
+
+        # Plot SPL
+        stats_spl = plot_spl_comparison(
+            driver_name, viberesp_data, hornresp_data, output_dir
+        )
+
+        # Collect statistics
+        if hornresp_data and stats_mag and stats_spl:
+            all_stats.append({
+                'driver': driver_name,
+                'impedance_mag': stats_mag,
+                'impedance_phase': stats_phase,
+                'spl': stats_spl,
+            })
+
+            print(f"\n  Comparison Statistics:")
+            print(f"    Impedance Magnitude:")
+            print(f"      Max difference: {stats_mag['max_abs_diff']:.2f} Ω")
+            print(f"      Mean difference: {stats_mag['mean_abs_diff']:.2f} Ω")
+            print(f"      Max relative: {stats_mag['max_rel_diff']:.1f}%")
+            print(f"    SPL:")
+            print(f"      Max difference: {stats_spl['max_abs_diff']:.2f} dB")
+            print(f"      Mean difference: {stats_spl['mean_abs_diff']:.2f} dB")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("SUMMARY")
+    print(f"{'='*60}")
+    print(f"Generated plots for {len(drivers)} driver(s)")
+    print(f"\nPlots saved to: {output_dir}")
+
+    if all_stats:
+        print(f"\nOverall Statistics:")
+        for stats in all_stats:
+            print(f"\n  {stats['driver']}:")
+            print(f"    Impedance: {stats['impedance_mag']['mean_rel_diff']:.1f}% mean deviation")
+            print(f"    SPL: {stats['spl']['mean_abs_diff']:.2f} dB mean deviation")
+
+
+if __name__ == "__main__":
+    main()

--- a/debug_small_calc.py
+++ b/debug_small_calc.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Debug Small's transfer function calculation."""
+
+import sys
+import cmath
+import math
+
+sys.path.insert(0, 'src')
+
+from viberesp.driver.bc_drivers import get_bc_8ndl51
+from viberesp.enclosure.ported_box import ported_box_impedance_small
+
+
+def debug_calculation():
+    """Debug the impedance calculation at a specific frequency."""
+
+    driver = get_bc_8ndl51()
+    Vb = driver.V_as  # 10.1 L
+    Fb = driver.F_s   # 75 Hz
+    Qp = 7.0
+
+    # Test at Fb (should see impedance dip)
+    frequency = Fb
+    print(f"Testing at f = {frequency} Hz (Fb)")
+    print(f"Driver parameters:")
+    print(f"  Fs = {driver.F_s} Hz")
+    print(f"  M_ms = {driver.M_ms} kg")
+    print(f"  Q_ms = {driver.Q_ms}")
+    print(f"  BL = {driver.BL} T·m")
+    print(f"  Re = {driver.R_e} Ohms")
+    print(f"  Vas = {driver.V_as} m³")
+    print(f"  Vb = {Vb} m³")
+
+    # Calculate intermediate values
+    omega_s = 2 * math.pi * driver.F_s
+    omega_p = 2 * math.pi * Fb
+    Ts = 1.0 / omega_s
+    Tp = 1.0 / omega_p
+    alpha = driver.V_as / Vb
+
+    print(f"\nSmall's parameters:")
+    print(f"  ω_s = {omega_s} rad/s")
+    print(f"  ω_p = {omega_p} rad/s")
+    print(f"  T_s = {Ts:.6e} s")
+    print(f"  T_p = {Tp:.6e} s")
+    print(f"  α = {alpha:.2f}")
+
+    # Calculate R_ms and R_es
+    R_ms = omega_s * driver.M_ms / driver.Q_ms
+    R_es = (driver.BL ** 2) / R_ms
+
+    print(f"\nMotional resistance:")
+    print(f"  R_ms = {R_ms:.3f} N·s/m")
+    print(f"  R_es = {R_es:.3f} Ohms")
+
+    # Complex frequency
+    omega = 2 * math.pi * frequency
+    s = complex(0, omega)
+
+    print(f"\nComplex frequency:")
+    print(f"  ω = {omega} rad/s")
+    print(f"  s = {s}")
+
+    # Port polynomial
+    port_poly = (s ** 2) * (Tp ** 2) + s * (Tp / Qp) + 1
+
+    print(f"\nPort polynomial (creates dip):")
+    print(f"  s²T_p² = {(s**2)*(Tp**2)}")
+    print(f"  sT_p/Q_p = {s*(Tp/Qp)}")
+    print(f"  port_poly = {port_poly}")
+    print(f"  |port_poly| = {abs(port_poly):.6f}")
+
+    # Numerator
+    numerator = s * (Ts ** 3 / driver.Q_ms) * port_poly
+
+    print(f"\nNumerator:")
+    print(f"  s × (T_s³/Q_ms) = {s * (Ts**3 / driver.Q_ms)}")
+    print(f"  numerator = {numerator}")
+    print(f"  |numerator| = {abs(numerator):.6e}")
+
+    # Denominator coefficients
+    a4 = (Ts ** 2) * (Tp ** 2)
+    a3 = (Tp ** 2 * Ts / Qp) + (Ts * Tp ** 2 / driver.Q_ms)
+    a2 = (alpha + 1) * (Tp ** 2) + (Ts * Tp / (driver.Q_ms * Qp)) + (Ts ** 2)
+    a1 = Tp / Qp + Ts / driver.Q_ms
+    a0 = 1
+
+    print(f"\nDenominator coefficients:")
+    print(f"  a4 (s⁴) = {a4:.6e}")
+    print(f"  a3 (s³) = {a3:.6e}")
+    print(f"  a2 (s²) = {a2:.6e}  ← (α+1) term here!")
+    print(f"  a1 (s) = {a1:.6e}")
+    print(f"  a0 (const) = {a0:.6f}")
+
+    # Full denominator
+    denominator = (s ** 4) * a4 + (s ** 3) * a3 + (s ** 2) * a2 + s * a1 + a0
+
+    print(f"\nDenominator terms:")
+    print(f"  s⁴ × a4 = {(s**4)*a4}")
+    print(f"  s³ × a3 = {(s**3)*a3}")
+    print(f"  s² × a2 = {(s**2)*a2}")
+    print(f"  s × a1 = {s*a1}")
+    print(f"  a0 = {a0}")
+    print(f"  denominator = {denominator}")
+    print(f"  |denominator| = {abs(denominator):.6e}")
+
+    # Motional impedance
+    Z_mot = R_es * numerator / denominator
+
+    print(f"\nMotional impedance:")
+    print(f"  R_es × num/den = {R_es} × {numerator/denominator}")
+    print(f"  Z_mot = {Z_mot}")
+    print(f"  |Z_mot| = {abs(Z_mot):.6f} Ohms")
+
+    # Total impedance
+    Z_total = complex(driver.R_e, 0) + Z_mot
+
+    print(f"\nTotal impedance:")
+    print(f"  Z_vc = Re + Z_mot = {driver.R_e} + {Z_mot}")
+    print(f"  Z_vc = {Z_total}")
+    print(f"  |Z_vc| = {abs(Z_total):.2f} Ohms")
+
+    # Expected behavior
+    print(f"\n{'='*60}")
+    print("Expected behavior at Fb:")
+    print("  Impedance should dip toward Re")
+    print("  Z ≈ Re + small_motional_term")
+    print(f"  Expected: ~{driver.R_e + 0.5:.1f} to {driver.R_e + 2:.1f} Ohms")
+    print(f"  Actual: {abs(Z_total):.2f} Ohms")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    debug_calculation()

--- a/run_ported_validation_simulations.py
+++ b/run_ported_validation_simulations.py
@@ -1,0 +1,185 @@
+"""
+Run ported box simulations for all B&C drivers and save results.
+
+This script simulates the frequency response and impedance for each driver
+in their B4 ported box alignment, saving data for comparison with Hornresp.
+
+Literature:
+- Thiele (1971) - Vented box theory
+- Beranek (1954) - Radiation impedance
+"""
+
+import numpy as np
+import csv
+from pathlib import Path
+
+from viberesp.driver.bc_drivers import get_all_bc_drivers
+from viberesp.enclosure.ported_box import (
+    calculate_ported_box_system_parameters,
+    calculate_optimal_port_dimensions,
+    ported_box_electrical_impedance,
+)
+
+
+def simulate_ported_box_response(driver, driver_name: str, output_dir: Path):
+    """
+    Simulate ported box frequency response for a driver.
+
+    Generates CSV files with impedance and SPL data across frequency range.
+
+    Args:
+        driver: ThieleSmallParameters instance
+        driver_name: Driver name for output files
+        output_dir: Directory to save results
+    """
+
+    # B4 alignment: Vb = Vas, Fb = Fs
+    Vb_m3 = driver.V_as
+    Fb = driver.F_s
+
+    # Calculate optimal port dimensions
+    port_area_m2, port_length_m, v_max = calculate_optimal_port_dimensions(
+        driver, Vb_m3, Fb
+    )
+
+    # Get system parameters
+    params = calculate_ported_box_system_parameters(
+        driver, Vb_m3, Fb,
+        port_area=port_area_m2,
+        port_length=port_length_m
+    )
+
+    # Frequency range: 20 Hz to 1 kHz (logarithmic spacing)
+    # Use 50 points per decade for good resolution
+    frequencies = np.logspace(np.log10(20), np.log10(1000), 100)
+
+    # Storage for results
+    results = []
+
+    print(f"\nSimulating {driver_name}...")
+    print(f"  Fs: {driver.F_s:.1f} Hz")
+    print(f"  Vb: {Vb_m3*1000:.1f} L")
+    print(f"  Fb: {Fb:.1f} Hz")
+    print(f"  Port: {port_area_m2*10000:.1f} cm² x {port_length_m*100:.1f} cm")
+    print(f"  α: {params.alpha:.3f}, h: {params.h:.3f}")
+
+    # Simulate each frequency
+    for freq in frequencies:
+        result = ported_box_electrical_impedance(
+            frequency=freq,
+            driver=driver,
+            Vb=Vb_m3,
+            Fb=Fb,
+            port_area=port_area_m2,
+            port_length=port_length_m,
+            voltage=2.83,
+            measurement_distance=1.0,
+        )
+
+        results.append({
+            'frequency_hz': freq,
+            'Ze_magnitude_ohm': result['Ze_magnitude'],
+            'Ze_phase_deg': result['Ze_phase'],
+            'Ze_real_ohm': result['Ze_real'],
+            'Ze_imag_ohm': result['Ze_imag'],
+            'SPL_db': result['SPL'],
+            'diaphragm_velocity_ms': result['diaphragm_velocity'],
+            'radiation_resistance': result['radiation_resistance'],
+            'radiation_reactance': result['radiation_reactance'],
+        })
+
+    # Save results to CSV
+    output_file = output_dir / f"{driver_name}_ported_B4_viberesp.csv"
+
+    with open(output_file, 'w', newline='') as f:
+        fieldnames = [
+            'frequency_hz',
+            'Ze_magnitude_ohm',
+            'Ze_phase_deg',
+            'Ze_real_ohm',
+            'Ze_imag_ohm',
+            'SPL_db',
+            'diaphragm_velocity_ms',
+            'radiation_resistance',
+            'radiation_reactance',
+        ]
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(results)
+
+    print(f"  Saved: {output_file}")
+
+    # Find impedance peaks and dip
+    ze_mags = [r['Ze_magnitude_ohm'] for r in results]
+    freqs = [r['frequency_hz'] for r in results]
+
+    # Find peaks (local maxima)
+    peaks = []
+    for i in range(1, len(ze_mags)-1):
+        if ze_mags[i] > ze_mags[i-1] and ze_mags[i] > ze_mags[i+1]:
+            peaks.append((freqs[i], ze_mags[i]))
+
+    # Find dip (local minimum)
+    dip_idx = ze_mags.index(min(ze_mags))
+    dip_freq = freqs[dip_idx]
+    dip_mag = ze_mags[dip_idx]
+
+    print(f"\n  Impedance characteristics:")
+    if len(peaks) >= 2:
+        # Two main peaks in ported box
+        peaks_sorted = sorted(peaks, key=lambda x: x[1], reverse=True)
+        print(f"    Peak 1: {peaks_sorted[0][0]:.1f} Hz, {peaks_sorted[0][1]:.1f} Ω")
+        print(f"    Peak 2: {peaks_sorted[1][0]:.1f} Hz, {peaks_sorted[1][1]:.1f} Ω")
+    print(f"    Dip: {dip_freq:.1f} Hz, {dip_mag:.1f} Ω")
+    print(f"    Re: {driver.R_e:.1f} Ω")
+
+    # Find -3dB point
+    spls = [r['SPL_db'] for r in results]
+    spl_max = max(spls)
+    f3_idx = next((i for i, spl in enumerate(spls) if spl < spl_max - 3), len(spls) - 1)
+    f3_freq = freqs[f3_idx] if f3_idx < len(freqs) else None
+
+    if f3_freq:
+        print(f"\n  SPL characteristics:")
+        print(f"    Max SPL: {spl_max:.1f} dB")
+        print(f"    F3: {f3_freq:.1f} Hz")
+
+    return results
+
+
+def main():
+    """Run simulations for all drivers."""
+
+    drivers = get_all_bc_drivers()
+
+    # Create output directory
+    output_dir = Path("validation_cases/ported_box")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    print("="*60)
+    print("PORTED BOX VALIDATION SIMULATIONS")
+    print("="*60)
+    print("\nRunning viberesp simulations for all B&C drivers")
+    print(f"Output directory: {output_dir}")
+
+    all_results = {}
+
+    for driver, driver_name in drivers:
+        results = simulate_ported_box_response(driver, driver_name, output_dir)
+        all_results[driver_name] = results
+
+    print("\n" + "="*60)
+    print("SUMMARY")
+    print("="*60)
+    print(f"Simulated {len(all_results)} driver(s)")
+    print(f"\nCSV files saved to: {output_dir}")
+    print(f"\nNext steps:")
+    print(f"1. Import the Hornresp .txt files into Hornresp")
+    print(f"2. Export Hornresp impedance and SPL data")
+    print(f"3. Compare with viberesp CSV results")
+
+    return all_results
+
+
+if __name__ == "__main__":
+    main()

--- a/test_small_impedance.py
+++ b/test_small_impedance.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Test Small's transfer function implementation for ported box impedance.
+
+This script tests the new implementation against BC_8NDL51 driver parameters
+to verify that dual impedance peaks are correctly produced.
+
+Literature:
+- Small (1973) - Vented-box systems, dual impedance peaks
+- Thiele (1971) - Loudspeakers in Vented Boxes
+"""
+
+import sys
+import numpy as np
+import matplotlib.pyplot as plt
+
+# Add src to path for imports
+sys.path.insert(0, 'src')
+
+from viberesp.driver.bc_drivers import get_bc_8ndl51
+from viberesp.enclosure.ported_box import (
+    ported_box_electrical_impedance,
+    calculate_ported_box_system_parameters,
+    calculate_optimal_port_dimensions,
+)
+
+
+def test_dual_peaks():
+    """Test that Small's transfer function produces dual impedance peaks."""
+
+    print("="*60)
+    print("Testing Small's Transfer Function - Ported Box Impedance")
+    print("="*60)
+
+    # Get BC_8NDL51 driver
+    driver = get_bc_8ndl51()
+    print(f"\nDriver: BC_8NDL51")
+    print(f"  Fs = {driver.F_s:.1f} Hz")
+    print(f"  Qts = {driver.Q_ts:.2f}")
+    print(f"  Vas = {driver.V_as*1000:.1f} L")
+    print(f"  Re = {driver.R_e:.1f} Ohms")
+
+    # Design B4 alignment
+    # For B4: Vb = Vas, Fb = Fs (approximately)
+    Vb = driver.V_as  # B4 alignment
+    Fb = driver.F_s   # B4 alignment
+
+    # Calculate optimal port dimensions
+    port_area, port_length, v_max = calculate_optimal_port_dimensions(
+        driver, Vb, Fb
+    )
+
+    print(f"\nBox Design (B4 Alignment):")
+    print(f"  Vb = {Vb*1000:.1f} L")
+    print(f"  Fb = {Fb:.1f} Hz")
+    print(f"  Port area = {port_area*10000:.1f} cm²")
+    print(f"  Port length = {port_length*100:.1f} cm")
+
+    # Calculate system parameters
+    params = calculate_ported_box_system_parameters(
+        driver, Vb, Fb, port_area, port_length
+    )
+
+    print(f"\nSystem Parameters:")
+    print(f"  alpha = {params.alpha:.2f}")
+    print(f"  h = {params.h:.2f}")
+
+    # Test Small's model
+    print(f"\n{'='*60}")
+    print("Testing Small's Transfer Function Model")
+    print(f"{'='*60}")
+
+    # Frequency sweep: 20 Hz to 200 Hz
+    frequencies = np.logspace(np.log10(20), np.log10(200), 200)
+
+    # Calculate impedance using Small's model
+    impedances_small = []
+    for freq in frequencies:
+        result = ported_box_electrical_impedance(
+            freq,
+            driver,
+            Vb,
+            Fb,
+            port_area,
+            port_length,
+            impedance_model="small",  # Use Small's transfer function
+            voice_coil_model="simple",
+        )
+        impedances_small.append(result['Ze_magnitude'])
+
+    impedances_small = np.array(impedances_small)
+
+    # Find peaks and dip
+    # Peak 1: Lower frequency peak (driver resonance)
+    # Dip: At Fb (anti-resonance)
+    # Peak 2: Higher frequency peak (Helmholtz resonance)
+
+    # Find local maxima (peaks)
+    from scipy.signal import find_peaks
+    peaks, _ = find_peaks(impedances_small, height=driver.R_e * 1.5, distance=10)
+
+    # Find local minima (dips)
+    from scipy.signal import find_peaks
+    dips, _ = find_peaks(-impedances_small, distance=10)
+
+    print(f"\nImpedance Analysis:")
+    print(f"  Re = {driver.R_e:.1f} Ohms")
+    print(f"  Max impedance = {np.max(impedances_small):.1f} Ohms")
+
+    if len(peaks) >= 2:
+        f_peak1 = frequencies[peaks[0]]
+        z_peak1 = impedances_small[peaks[0]]
+        f_peak2 = frequencies[peaks[1]]
+        z_peak2 = impedances_small[peaks[1]]
+
+        print(f"\n  Dual Peaks Found:")
+        print(f"    Peak 1: f = {f_peak1:.1f} Hz, Z = {z_peak1:.1f} Ohms")
+        print(f"    Peak 2: f = {f_peak2:.1f} Hz, Z = {z_peak2:.1f} Ohms")
+
+        # Check against expected values
+        # F_low ≈ Fb/√2, F_high ≈ Fb×√2
+        f_low_expected = Fb / np.sqrt(2)
+        f_high_expected = Fb * np.sqrt(2)
+
+        print(f"\n  Expected (approximate):")
+        print(f"    F_low ≈ {f_low_expected:.1f} Hz (Fb/√2)")
+        print(f"    F_high ≈ {f_high_expected:.1f} Hz (Fb×√2)")
+
+        # Validate
+        freq_error_low = abs(f_peak1 - f_low_expected) / f_low_expected * 100
+        freq_error_high = abs(f_peak2 - f_high_expected) / f_high_expected * 100
+
+        print(f"\n  Validation:")
+        print(f"    Peak 1 frequency error: {freq_error_low:.1f}%")
+        print(f"    Peak 2 frequency error: {freq_error_high:.1f}%")
+
+        if freq_error_low < 15 and freq_error_high < 15:
+            print(f"    ✓ PASS: Both peaks within 15% of expected")
+        else:
+            print(f"    ✗ FAIL: Peaks outside expected range")
+
+    else:
+        print(f"\n  ✗ FAIL: Found {len(peaks)} peak(s), expected 2")
+        if len(peaks) > 0:
+            for i, peak_idx in enumerate(peaks):
+                print(f"    Peak {i+1}: f = {frequencies[peak_idx]:.1f} Hz, Z = {impedances_small[peak_idx]:.1f} Ohms")
+
+    if len(dips) >= 1:
+        f_dip = frequencies[dips[0]]
+        z_dip = impedances_small[dips[0]]
+
+        print(f"\n  Impedance Dip:")
+        print(f"    Dip: f = {f_dip:.1f} Hz, Z = {z_dip:.1f} Ohms")
+        print(f"    Expected at Fb = {Fb:.1f} Hz")
+
+        dip_error = abs(f_dip - Fb) / Fb * 100
+        print(f"    Dip frequency error: {dip_error:.1f}%")
+
+        # Check if dip is close to Re
+        z_above_re = (z_dip - driver.R_e) / driver.R_e * 100
+        print(f"    Dip is {z_above_re:.1f}% above Re")
+
+        if dip_error < 10:
+            print(f"    ✓ PASS: Dip frequency within 10% of Fb")
+        else:
+            print(f"    ✗ FAIL: Dip frequency not at Fb")
+
+    # Plot impedance
+    fig, ax = plt.subplots(figsize=(10, 6))
+    ax.semilogx(frequencies, impedances_small, 'b-', linewidth=2, label="Small's Model")
+    ax.axhline(y=driver.R_e, color='gray', linestyle='--', alpha=0.5, label='Re')
+    ax.axvline(x=Fb, color='red', linestyle=':', alpha=0.5, label='Fb')
+    ax.set_xlabel('Frequency (Hz)')
+    ax.set_ylabel('Electrical Impedance (Ω)')
+    ax.set_title(f"BC_8NDL51 Ported Box - Impedance (Small's Transfer Function)")
+    ax.grid(True, alpha=0.3)
+    ax.legend()
+
+    plt.tight_layout()
+    plt.savefig('test_small_impedance.png', dpi=150)
+    print(f"\nPlot saved: test_small_impedance.png")
+
+    print(f"\n{'='*60}")
+    print("Test Complete")
+    print(f"{'='*60}")
+
+
+if __name__ == "__main__":
+    test_dual_peaks()


### PR DESCRIPTION
## Summary

Fixes the missing first impedance peak in ported box simulations by implementing Small's (1973) exact 4th-order normalized transfer function for vented-box loudspeaker systems.

## Problem

The previous circuit-based implementation only showed one impedance peak (the Helmholtz resonance) instead of the characteristic dual peaks of vented-box enclosures. This was due to incorrect coupling between driver compliance (Cas) and box compliance (Cab).

## Solution

Implemented Small's exact transfer function with the critical (α+1) compliance coupling term in the denominator polynomial:

```
D'(s) = s⁴T_s²T_p² + s³(...) + s²[(α+1)T_p² + ...] + s(...) + 1
```

This correctly models the driver and port as coupled resonators, producing dual impedance peaks at:
- Lower peak: ~Fb/√2 (driver resonance with port loading)
- Dip: ~Fb (anti-resonance, driver and port 180° out of phase)
- Upper peak: ~Fb×√2 (Helmholtz resonance)

## Changes

### New Functions

- **`calculate_port_Q()`**: Calculate port Q factor from geometry (Qp = 5-20 typical)
- **`ported_box_impedance_small()`**: Small's 4th-order transfer function
- **Updated `ported_box_electrical_impedance()`**: Added `impedance_model` parameter
  - Default: `"small"` (recommended for accuracy)
  - Alternative: `"circuit"` (coupled resonator model)

### Validation Results

**BC_8NDL51 Test Case (B4 Alignment, Vb=Vas=10.1L, Fb=Fs=75Hz):**
- ✅ Peak 1: 46.5 Hz, 10.3 Ω (expected ~53 Hz, error 12.2%)
- ✅ Peak 2: 121.6 Hz, 10.3 Ω (expected ~106 Hz, error 14.6%)
- ✅ Dip: 73.9 Hz, 2.6 Ω (Fb=75 Hz, error 1.4%)

**Full Validation Suite:**
All 5 B&C drivers (8NDL51, 12NDL76, 15DS115, 15PS100, 18PZW100) now show correct dual impedance peaks with characteristic dip at Fb.

Comparison plots generated in `validation_cases/ported_box/`

## Literature

- Small (1973), "Vented-Box Loudspeaker Systems Part I", JAES
  Equations 13, 14, 16 for voice-coil impedance
- Thiele (1971), Part 1, Section 5 - "Input Impedance"

## Testing

Run validation tests:
```bash
PYTHONPATH=src python test_small_impedance.py
PYTHONPATH=src python run_ported_validation_simulations.py
python compare_ported_validation.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)