### PR TITLE
fix: Resolve circular import in horn_driver_integration module

### DIFF
--- a/src/viberesp/simulation/horn_driver_integration.py
+++ b/src/viberesp/simulation/horn_driver_integration.py
@@ -13,13 +13,13 @@ Literature:
 - literature/thiele_small/small_1972_closed_box.md
 """
 
+from __future__ import annotations
+
 import math
 import cmath
 from typing import Optional, Tuple
 import numpy as np
 from numpy.typing import NDArray
-
-from viberesp.driver.parameters import ThieleSmallParameters
 from viberesp.simulation.horn_theory import (
     exponential_horn_throat_impedance,
     circular_piston_radiation_impedance,
@@ -372,6 +372,9 @@ def horn_electrical_impedance(
     # Validate inputs
     if frequency <= 0:
         raise ValueError(f"Frequency must be > 0, got {frequency} Hz")
+
+    # Local import to avoid circular dependency
+    from viberesp.driver.parameters import ThieleSmallParameters
 
     if not isinstance(driver, ThieleSmallParameters):
         raise TypeError(f"driver must be ThieleSmallParameters, got {type(driver)}")


### PR DESCRIPTION
## Summary
- Fixed circular import that prevented all CLI commands from running
- Commands like `viberesp driver list` would fail with `ImportError: cannot import name 'ThieleSmallParameters' from partially initialized module`

## Root Cause
Circular dependency in the import chain:
```
cli.py → driver.parameters → simulation.constants → simulation.__init__.py
  → horn_driver_integration → driver.parameters (circular!)
```

## Changes
**File: `src/viberesp/simulation/horn_driver_integration.py`**
- Added `from __future__ import annotations` to defer type evaluation
- Removed top-level import of `ThieleSmallParameters` 
- Added local import inside `horn_electrical_impedance()` function for the `isinstance` check

## How It Works
The fix uses Python's `from __future__ import annotations` (PEP 563) to make all type annotations strings by default, preventing them from being evaluated at import time. The `ThieleSmallParameters` import is now done locally inside the function that needs it for the runtime `isinstance` check.

This breaks the circular dependency by deferring the import until the function is called, rather than at module import time.

## Test Plan
- [x] `viberesp driver list` - Works ✓
- [x] `viberesp validate list` - Works ✓
- [x] `viberesp --help` - Works ✓
- [x] All CLI commands now functional

## Impact
- Minimal code change (3 lines modified)
- No behavior changes
- No API changes
- Fixes critical bug preventing all CLI usage